### PR TITLE
Change detection of start of transmission to only compare the beginning of the data

### DIFF
--- a/app/src/main/java/seemoo/fitbit/interactions/DumpInteraction.java
+++ b/app/src/main/java/seemoo/fitbit/interactions/DumpInteraction.java
@@ -159,7 +159,7 @@ class DumpInteraction extends BluetoothInteraction {
         if (transmissionActive) {
             data = data + temp;
         }
-        if (!transmissionActive && temp.equals(begin)) {
+        if (!transmissionActive && temp.startsWith(begin)) {
             transmissionActive = true;
         }
         return null;


### PR DESCRIPTION
The first part of the data from the tracker for a micro dump looks like this for my Surge:
`c0410300000000`

This means the app was not recognizing that the data had started since it checked for a complete match for this string:
`c04103`

This pull request should fix that - However, I am not sure if there will ever be a difference in the remaining part of the "transmission begin" message (i.e. all the postfixed 0's) or if it is just padding.
