### PR TITLE
bluetooth disconnect now added as task in onPause: if transmission is…

### DIFF
--- a/app/src/main/java/seemoo/fitbit/activities/WorkActivity.java
+++ b/app/src/main/java/seemoo/fitbit/activities/WorkActivity.java
@@ -373,14 +373,11 @@ public class WorkActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        if (commands != null) {
-            commands.close();
-        }
+        tasks.clearList();
+        interactions.disconnectBluetooth();
         mWebView.clearHistory();
         toast_short.cancel();
         toast_long.cancel();
-        FitbitDevice.clearCache();
-        tasks.clearList();
     }
 
     /**

--- a/app/src/main/java/seemoo/fitbit/interactions/DisconnectBluetoothInteraction.java
+++ b/app/src/main/java/seemoo/fitbit/interactions/DisconnectBluetoothInteraction.java
@@ -1,0 +1,47 @@
+package seemoo.fitbit.interactions;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+import seemoo.fitbit.commands.Commands;
+import seemoo.fitbit.information.InformationList;
+import seemoo.fitbit.miscellaneous.FitbitDevice;
+
+/**
+ * Switches to live mode.
+ */
+class DisconnectBluetoothInteraction extends BluetoothInteraction {
+
+    private final String TAG = this.getClass().getSimpleName();
+
+    private Commands commands;
+
+    DisconnectBluetoothInteraction(Commands commands) {
+        this.commands = commands;
+        setTimer(600000);
+    }
+
+    @Override
+    boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    boolean execute() {
+        Log.i(TAG, "Will now disconnect bluetooth");
+        if(commands != null){
+            commands.close();
+        }
+        FitbitDevice.clearCache();
+        return true;
+    }
+
+    @Override
+    @Nullable InformationList interact(byte[] value) {
+        return null;
+    }
+
+    @Override
+    @Nullable InformationList finish() {
+        return null;
+    }
+}

--- a/app/src/main/java/seemoo/fitbit/interactions/Interactions.java
+++ b/app/src/main/java/seemoo/fitbit/interactions/Interactions.java
@@ -358,4 +358,8 @@ public class Interactions {
     public void intConsolePrintf(){
         mBluetoothInteractionQueue.addInteraction(new EmptyInteraction(this));
     }
+
+    public void disconnectBluetooth() {
+        mBluetoothInteractionQueue.addInteraction(new DisconnectBluetoothInteraction(commands));
+    }
 }

--- a/app/src/main/java/seemoo/fitbit/miscellaneous/FitbitDevice.java
+++ b/app/src/main/java/seemoo/fitbit/miscellaneous/FitbitDevice.java
@@ -43,7 +43,6 @@ public class FitbitDevice {
      */
     public static void setEncryptionKey(String value) {
         ENCRYPTION_KEY = value;
-        Log.i("Johannes","set Enc key to " + value);
     }
 
     /**


### PR DESCRIPTION
… currently running it is now not aborted when display is powered off, but instead disconnect is executed after transmission ended

fixes #11 