### PR TITLE
Feature/bugfix firmware flash dialog

### DIFF
--- a/app/src/main/java/seemoo/fitbit/activities/WorkActivity.java
+++ b/app/src/main/java/seemoo/fitbit/activities/WorkActivity.java
@@ -45,6 +45,7 @@ public class WorkActivity extends RequestPermissionsActivity implements Serializ
     private HttpsClient client;
 
     private boolean backClosesAppToastShown = false;
+    private boolean bluetoothDisconnectOnPause = true;
     private MainFragment mainFragment;
     private WebViewFragment webViewFragment;
     private DirectoryPickerFragment directoryPickerFragment;
@@ -383,5 +384,16 @@ public class WorkActivity extends RequestPermissionsActivity implements Serializ
     public void setDumpMenuButtonActive() {
         navigationView.getMenu().findItem(R.id.nav_dump).setChecked(true);
         leaveLiveModeIfActiveBefore();
+    }
+
+    public void disableBluetoothDisconnectOnPause() {
+        bluetoothDisconnectOnPause = false;
+    }
+    public void enableBluetoothDisconnectOnPause() {
+        bluetoothDisconnectOnPause = false;
+    }
+
+    public boolean isBluetoothDisconnectOnPause() {
+        return bluetoothDisconnectOnPause;
     }
 }

--- a/app/src/main/java/seemoo/fitbit/activities/WorkActivity.java
+++ b/app/src/main/java/seemoo/fitbit/activities/WorkActivity.java
@@ -280,11 +280,11 @@ public class WorkActivity extends RequestPermissionsActivity implements Serializ
     private void handleFirmwareFlashButton() {
         fwFlashDialog = new FirmwareFlashDialog(WorkActivity.this, mainFragment);
         fwFlashDialog.show();
-        //startActivityForResult(new Intent(),0);
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == FirmwareFlashDialog.PICK_FWFILE_REQUEST) {
             if (resultCode == RESULT_OK) {
                 fwFlashDialog.passActivityResult(data);

--- a/app/src/main/java/seemoo/fitbit/dialogs/FirmwareFlashDialog.java
+++ b/app/src/main/java/seemoo/fitbit/dialogs/FirmwareFlashDialog.java
@@ -48,6 +48,7 @@ import seemoo.fitbit.activities.MainActivity;
 import seemoo.fitbit.activities.WorkActivity;
 import seemoo.fitbit.events.TransferProgressEvent;
 import seemoo.fitbit.fragments.MainFragment;
+import seemoo.fitbit.miscellaneous.FileUriHelper;
 
 public class FirmwareFlashDialog extends Dialog implements Serializable {
 
@@ -154,135 +155,6 @@ public class FirmwareFlashDialog extends Dialog implements Serializable {
         });
     }
 
-
-    /**
-     * Get a file path from a Uri. This will get the the path for Storage Access
-     * Framework Documents, as well as the _data field for the MediaStore and
-     * other file-based ContentProviders.
-     *
-     * @param context The context.
-     * @param uri     The Uri to query.
-     * @author paulburke
-     */
-    public static String getPath(final Context context, final Uri uri) {
-
-        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
-
-        // DocumentProvider
-        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-            // ExternalStorageProvider
-            if (isExternalStorageDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-
-                if ("primary".equalsIgnoreCase(type)) {
-                    return Environment.getExternalStorageDirectory() + "/" + split[1];
-                } else {
-                    Toast.makeText(context, "Error. Only internal storage supported.", Toast.LENGTH_LONG).show();
-                }
-            }
-            // DownloadsProvider
-            else if (isDownloadsDocument(uri)) {
-
-                final String id = DocumentsContract.getDocumentId(uri);
-                final Uri contentUri = ContentUris.withAppendedId(
-                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-
-                return getDataColumn(context, contentUri, null, null);
-            }
-            // MediaProvider
-            else if (isMediaDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-
-                Uri contentUri = null;
-                if ("image".equals(type)) {
-                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                } else if ("video".equals(type)) {
-                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                } else if ("audio".equals(type)) {
-                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                }
-
-                final String selection = "_id=?";
-                final String[] selectionArgs = new String[]{
-                        split[1]
-                };
-
-                return getDataColumn(context, contentUri, selection, selectionArgs);
-            }
-        }
-        // MediaStore (and general)
-        else if ("content".equalsIgnoreCase(uri.getScheme())) {
-            return getDataColumn(context, uri, null, null);
-        }
-        // File
-        else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            return uri.getPath();
-        }
-
-        return null;
-    }
-
-    /**
-     * Get the value of the data column for this Uri. This is useful for
-     * MediaStore Uris, and other file-based ContentProviders.
-     *
-     * @param context       The context.
-     * @param uri           The Uri to query.
-     * @param selection     (Optional) Filter used in the query.
-     * @param selectionArgs (Optional) Selection arguments used in the query.
-     * @return The value of the _data column, which is typically a file path.
-     */
-    public static String getDataColumn(Context context, Uri uri, String selection,
-                                       String[] selectionArgs) {
-
-        Cursor cursor = null;
-        final String column = "_data";
-        final String[] projection = {
-                column
-        };
-
-        try {
-            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                    null);
-            if (cursor != null && cursor.moveToFirst()) {
-                final int column_index = cursor.getColumnIndexOrThrow(column);
-                return cursor.getString(column_index);
-            }
-        } finally {
-            if (cursor != null)
-                cursor.close();
-        }
-        return null;
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is ExternalStorageProvider.
-     */
-    public static boolean isExternalStorageDocument(Uri uri) {
-        return "com.android.externalstorage.documents".equals(uri.getAuthority());
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is DownloadsProvider.
-     */
-    public static boolean isDownloadsDocument(Uri uri) {
-        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-    }
-
-    /**
-     * @param uri The Uri to check.
-     * @return Whether the Uri authority is MediaProvider.
-     */
-    public static boolean isMediaDocument(Uri uri) {
-        return "com.android.providers.media.documents".equals(uri.getAuthority());
-    }
-
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMessageEvent(TransferProgressEvent event) {
         if (event.getEvent_type() == TransferProgressEvent.EVENT_TYPE_FW) {
@@ -312,7 +184,7 @@ public class FirmwareFlashDialog extends Dialog implements Serializable {
     }
 
     public void passActivityResult(Intent data) {
-        String path = getPath(getContext(), data.getData());
+        String path = FileUriHelper.getPath(getContext(), data.getData());
         onFilePickerResult(path);
     }
 

--- a/app/src/main/java/seemoo/fitbit/dialogs/FirmwareFlashDialog.java
+++ b/app/src/main/java/seemoo/fitbit/dialogs/FirmwareFlashDialog.java
@@ -106,6 +106,7 @@ public class FirmwareFlashDialog extends Dialog implements Serializable {
         btn_fwfile_select.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                mActivity.disableBluetoothDisconnectOnPause();
                 Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
                 intent.addCategory(Intent.CATEGORY_OPENABLE);
                 intent.setType("application/octet-stream");
@@ -184,6 +185,7 @@ public class FirmwareFlashDialog extends Dialog implements Serializable {
     }
 
     public void passActivityResult(Intent data) {
+        mActivity.enableBluetoothDisconnectOnPause();
         String path = FileUriHelper.getPath(getContext(), data.getData());
         onFilePickerResult(path);
     }

--- a/app/src/main/java/seemoo/fitbit/fragments/DirectoryPickerFragment.java
+++ b/app/src/main/java/seemoo/fitbit/fragments/DirectoryPickerFragment.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 
 import seemoo.fitbit.R;
 import seemoo.fitbit.activities.WorkActivity;
+import seemoo.fitbit.miscellaneous.FileUriHelper;
 
 import static android.app.Activity.RESULT_OK;
 
@@ -89,31 +90,13 @@ public class DirectoryPickerFragment extends Fragment {
             Uri uri = data.getData();
             Uri docUri = DocumentsContract.buildDocumentUriUsingTree(uri,
                     DocumentsContract.getTreeDocumentId(uri));
-            String path = DirectoryPickerFragment.getPath(getContext(), docUri);
+            String path = FileUriHelper.getPath(getContext(), docUri);
             onDirectoyDialogResult(path);
         }
     }
 
     public void onDirectoyDialogResult(String path){
         editText.setText(path);
-    }
-
-    public static String getPath(final Context context, final Uri uri) {
-        if (DocumentsContract.isDocumentUri(context, uri) &&
-                "com.android.externalstorage.documents".equals(uri.getAuthority())) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-                if ("primary".equalsIgnoreCase(type)) {
-                    if(split.length > 1){
-                        return Environment.getExternalStorageDirectory() + "/" + split[1];
-                    } else {
-                        return Environment.getExternalStorageDirectory().getPath();
-                    }
-                }
-        }
-        Toast.makeText(context, "Error. Only internal storage supported.",Toast.LENGTH_LONG).show();
-        return "";
     }
 
 }

--- a/app/src/main/java/seemoo/fitbit/fragments/MainFragment.java
+++ b/app/src/main/java/seemoo/fitbit/fragments/MainFragment.java
@@ -485,58 +485,60 @@ public class MainFragment extends Fragment {
      * Collects basic information about the selected device, stores them in 'information' and displays them to the user.
      */
     public void collectBasicInformation() {
-        if (!firstPress) {
-            saveButton.setVisibility(View.VISIBLE);
-        }
-        InformationList list = new InformationList("basic");
-        currentInformationList = "basic";
-        list.add(new Information("MAC Address: " + device.getAddress()));
-        list.add(new Information("Name: " + device.getName()));
-
-        int type = device.getType();
-        if (type == BluetoothDevice.DEVICE_TYPE_UNKNOWN) {
-            list.add(new Information(getString(R.string.device_type0)));
-        } else if (type == BluetoothDevice.DEVICE_TYPE_CLASSIC) {
-            list.add(new Information(getString(R.string.device_type1)));
-        } else if (type == BluetoothDevice.DEVICE_TYPE_LE) {
-            list.add(new Information(getString(R.string.device_type2)));
-        } else if (type == BluetoothDevice.DEVICE_TYPE_DUAL) {
-            list.add(new Information(getString(R.string.device_type3)));
-        }
-
-        int bondState = device.getBondState();
-        if (bondState == BluetoothDevice.BOND_NONE) {
-            list.add(new Information(getString(R.string.bond_state0)));
-        } else if (bondState == BluetoothDevice.BOND_BONDING) {
-            list.add(new Information(getString(R.string.bond_state1)));
-        } else if (bondState == BluetoothDevice.BOND_BONDED) {
-            list.add(new Information(getString(R.string.bond_state2)));
-        }
-
-
-        InternalStorage.loadAuthFiles(getActivity());
-
-        if (FitbitDevice.AUTHENTICATION_KEY == null || FitbitDevice.AUTHENTICATION_KEY.equals("")) {
-            list.add(new Information(getString(R.string.no_auth_cred)));
-        } else {
-            list.add(new Information("Authentication Key & Nonce: " + FitbitDevice.AUTHENTICATION_KEY + ", " + FitbitDevice.NONCE));
-        }
-
-        if (FitbitDevice.ENCRYPTION_KEY == null || FitbitDevice.ENCRYPTION_KEY.equals("")) {
-            list.add(new Information(getString(R.string.no_enc_key)));
-        } else {
-            list.add(new Information("Encryption Key: " + FitbitDevice.ENCRYPTION_KEY));
-        }
-
-
-        information.put("basic", list);
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                informationToDisplay.override(information.get("basic"), mListView);
-
+        if(isAdded()){
+            if (!firstPress) {
+                saveButton.setVisibility(View.VISIBLE);
             }
-        }, 300);
+            InformationList list = new InformationList("basic");
+            currentInformationList = "basic";
+            list.add(new Information("MAC Address: " + device.getAddress()));
+            list.add(new Information("Name: " + device.getName()));
+
+            int type = device.getType();
+            if (type == BluetoothDevice.DEVICE_TYPE_UNKNOWN) {
+                list.add(new Information(getString(R.string.device_type0)));
+            } else if (type == BluetoothDevice.DEVICE_TYPE_CLASSIC) {
+                list.add(new Information(getString(R.string.device_type1)));
+            } else if (type == BluetoothDevice.DEVICE_TYPE_LE) {
+                list.add(new Information(getString(R.string.device_type2)));
+            } else if (type == BluetoothDevice.DEVICE_TYPE_DUAL) {
+                list.add(new Information(getString(R.string.device_type3)));
+            }
+
+            int bondState = device.getBondState();
+            if (bondState == BluetoothDevice.BOND_NONE) {
+                list.add(new Information(getString(R.string.bond_state0)));
+            } else if (bondState == BluetoothDevice.BOND_BONDING) {
+                list.add(new Information(getString(R.string.bond_state1)));
+            } else if (bondState == BluetoothDevice.BOND_BONDED) {
+                list.add(new Information(getString(R.string.bond_state2)));
+            }
+
+
+            InternalStorage.loadAuthFiles(getActivity());
+
+            if (FitbitDevice.AUTHENTICATION_KEY == null || FitbitDevice.AUTHENTICATION_KEY.equals("")) {
+                list.add(new Information(getString(R.string.no_auth_cred)));
+            } else {
+                list.add(new Information("Authentication Key & Nonce: " + FitbitDevice.AUTHENTICATION_KEY + ", " + FitbitDevice.NONCE));
+            }
+
+            if (FitbitDevice.ENCRYPTION_KEY == null || FitbitDevice.ENCRYPTION_KEY.equals("")) {
+                list.add(new Information(getString(R.string.no_enc_key)));
+            } else {
+                list.add(new Information("Encryption Key: " + FitbitDevice.ENCRYPTION_KEY));
+            }
+
+
+            information.put("basic", list);
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    informationToDisplay.override(information.get("basic"), mListView);
+
+                }
+            }, 300);
+        }
     }
 
     public void checkFirstButtonPress() {

--- a/app/src/main/java/seemoo/fitbit/fragments/MainFragment.java
+++ b/app/src/main/java/seemoo/fitbit/fragments/MainFragment.java
@@ -929,8 +929,11 @@ public class MainFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-        tasks.clearList();
-        interactions.disconnectBluetooth();
+        WorkActivity workActivity = (WorkActivity) getActivity();
+        if(workActivity != null && workActivity.isBluetoothDisconnectOnPause()){
+            tasks.clearList();
+            interactions.disconnectBluetooth();
+        }
         toast_short.cancel();
         toast_long.cancel();
     }

--- a/app/src/main/java/seemoo/fitbit/miscellaneous/FileUriHelper.java
+++ b/app/src/main/java/seemoo/fitbit/miscellaneous/FileUriHelper.java
@@ -1,0 +1,28 @@
+package seemoo.fitbit.miscellaneous;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.widget.Toast;
+
+public class FileUriHelper {
+
+    public static String getPath(final Context context, final Uri uri) {
+        if (DocumentsContract.isDocumentUri(context, uri) &&
+                "com.android.externalstorage.documents".equals(uri.getAuthority())) {
+            final String docId = DocumentsContract.getDocumentId(uri);
+            final String[] split = docId.split(":");
+            final String type = split[0];
+            if ("primary".equalsIgnoreCase(type)) {
+                if(split.length > 1){
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                } else {
+                    return Environment.getExternalStorageDirectory().getPath();
+                }
+            }
+        }
+        Toast.makeText(context, "Error. Only internal storage paths supported.",Toast.LENGTH_LONG).show();
+        return "";
+    }
+}


### PR DESCRIPTION
- fix bug for fw flash dialog: if fw was selected via dialog, tracker was disconnected, which lead to problems if flashing should start after selection
- merged code to get path from android file/directory picker. solves prblem with "downloads" selection in fw flash dialog
- bugfix for crash if during collectBasicInformation fragment was switched 
- bugfix so that other fragments receive onActivityResult as well 

